### PR TITLE
feat: enable project index and context lookup

### DIFF
--- a/analysis/indexer.py
+++ b/analysis/indexer.py
@@ -1,0 +1,80 @@
+import ast
+import json
+import pathlib
+import re
+from typing import Dict, List, Tuple, Any
+
+IGNORED_DIRS = {'.git', 'venv', '__pycache__', '.cswarm'}
+
+
+def iter_python_files(root: pathlib.Path):
+    """Yield python files under *root* ignoring virtualenvs and git dirs."""
+    for path in root.rglob('*.py'):
+        rel_parts = path.relative_to(root).parts
+        if any(part in IGNORED_DIRS or part.startswith('.') for part in rel_parts[:-1]):
+            continue
+        yield path
+
+
+def parse_file(path: pathlib.Path) -> Dict[str, Any]:
+    """Return summary information for a python source file."""
+    source = path.read_text(encoding='utf-8', errors='ignore')
+    try:
+        tree = ast.parse(source)
+    except Exception:
+        tree = ast.parse(compile(source, str(path), 'exec'))
+
+    # file level docstring
+    summary = ast.get_docstring(tree) or ''
+
+    symbols = []
+    imports = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            symbols.append({
+                'name': node.name,
+                'lineno': node.lineno,
+                'doc': ast.get_docstring(node) or ''
+            })
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                imports.add(alias.name.split('.')[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                imports.add(node.module.split('.')[0])
+
+    # naive term frequency as lightweight "embedding"
+    terms: Dict[str, int] = {}
+    for tok in re.findall(r"[A-Za-z_]{3,}", source.lower()):
+        terms[tok] = terms.get(tok, 0) + 1
+
+    return {
+        'summary': summary,
+        'symbols': symbols,
+        'imports': sorted(imports),
+        'terms': terms,
+    }
+
+
+def build_index(project_root: str, output: str | None = None) -> Dict[str, Any]:
+    """
+    Traverse *project_root*, parse python files and build a lightweight
+    dependency and term index. The index is written to ``.cswarm/index.json``
+    unless *output* is provided. Returns the in-memory index dictionary.
+    """
+    root = pathlib.Path(project_root)
+    data: Dict[str, Any] = {'files': {}}
+    for path in iter_python_files(root):
+        rel = str(path.relative_to(root))
+        data['files'][rel] = parse_file(path)
+
+    out_path = pathlib.Path(output) if output else root / '.cswarm' / 'index.json'
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(data, indent=2), encoding='utf-8')
+    return data
+
+
+if __name__ == '__main__':
+    import sys
+    build_index(sys.argv[1] if len(sys.argv) > 1 else '.')

--- a/analysis/query.py
+++ b/analysis/query.py
@@ -1,0 +1,55 @@
+import json
+import pathlib
+import re
+from typing import Any, Dict, List
+
+
+class ProjectIndex:
+    """Simple helper around the index produced by :mod:`analysis.indexer`."""
+
+    def __init__(self, project_root: str):
+        self.root = pathlib.Path(project_root)
+        idx_path = self.root / '.cswarm' / 'index.json'
+        if idx_path.exists():
+            self.data: Dict[str, Any] = json.loads(idx_path.read_text(encoding='utf-8'))
+        else:
+            self.data = {'files': {}}
+
+    def _file_source(self, rel: str) -> List[str]:
+        try:
+            return (self.root / rel).read_text(encoding='utf-8', errors='ignore').splitlines()
+        except Exception:
+            return []
+
+    def by_symbol(self, name: str) -> List[Dict[str, Any]]:
+        results = []
+        for rel, info in self.data.get('files', {}).items():
+            for sym in info.get('symbols', []):
+                if sym['name'] == name:
+                    src = self._file_source(rel)
+                    start = max(sym['lineno'] - 5, 0)
+                    snippet = '\n'.join(src[start:start + 20])
+                    results.append({'path': rel, 'symbol': sym, 'snippet': snippet})
+        return results
+
+    def by_path(self, rel: str) -> List[Dict[str, Any]]:
+        info = self.data.get('files', {}).get(rel)
+        if not info:
+            return []
+        src = self._file_source(rel)[:200]
+        return [{'path': rel, 'summary': info.get('summary', ''), 'snippet': '\n'.join(src)}]
+
+    def by_text(self, text: str, limit: int = 5) -> List[Dict[str, Any]]:
+        tokens = re.findall(r"[A-Za-z_]{3,}", text.lower())
+        scored = []
+        for rel, info in self.data.get('files', {}).items():
+            score = sum(info.get('terms', {}).get(tok, 0) for tok in tokens)
+            if score:
+                src = self._file_source(rel)[:40]
+                scored.append((score, {
+                    'path': rel,
+                    'summary': info.get('summary', ''),
+                    'snippet': '\n'.join(src)
+                }))
+        scored.sort(key=lambda x: x[0], reverse=True)
+        return [item for _, item in scored[:limit]]

--- a/swarm_orchestrator.py
+++ b/swarm_orchestrator.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Optional, Dict, Any, List
 from datetime import datetime
 import typer, yaml, requests
+from analysis import indexer, query
 
 app = typer.Typer(add_completion=False)
 
@@ -95,11 +96,24 @@ def orchestrate(goal: str = typer.Option(..., "--goal", "-g"),
     call, ident = decide_provider(provider)
     typer.echo(f"[orchestrator] provider={ident}, max_iters={max_iters}")
 
-    system_preface = doc_lookup(doc_hints) + (f"Goal: {goal}\n")
+    # Build initial search index for the project
+    indexer.build_index(project)
+
     add_memory(project, "system", f"Start goal: {goal}")
 
     for it in range(1, max_iters+1):
         typer.echo(f"\n== Iteration {it}/{max_iters} ==")
+
+        # refresh context each iteration
+        indexer.build_index(project)
+        pindex = query.ProjectIndex(project)
+        ctx = pindex.by_text(goal)
+        ctx_txt = "".join(
+            f"{c['path']}:\n{c['snippet']}\n\n" for c in ctx
+        )
+        system_preface = doc_lookup(doc_hints) + (f"Goal: {goal}\n")
+        if ctx_txt:
+            system_preface += "Relevant project context:\n" + ctx_txt
 
         # 1) Architect
         architect = personas.get("architect","Design the steps, files to change, and tests to run.")


### PR DESCRIPTION
## Summary
- add `analysis.indexer` to scan python files and build dependency/term index
- expose `analysis.query` helpers to fetch snippets by symbol, path or text
- orchestrator builds/refreshed index each run and feeds relevant context to agents

## Testing
- `python - <<'PY'
from analysis import indexer, query
idx=indexer.build_index('.')
pi=query.ProjectIndex('.')
print('files', len(idx['files']))
print('symbol run', pi.by_symbol('run')[0]['path'])
print('text search', [r['path'] for r in pi.by_text('provider')][:3])
PY`
- `python -m py_compile analysis/indexer.py analysis/query.py swarm_orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_68aca444218c832485efb1ae2561d0e1