### PR TITLE
feat: add async task queue with rate limiting

### DIFF
--- a/bin/swarm_api.py
+++ b/bin/swarm_api.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-import os, subprocess
+import os, asyncio, uuid, time
 from pathlib import Path
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Dict
+from collections import deque
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
@@ -16,6 +17,17 @@ if os.path.exists(ENV_FILE):
                 k,v=line.strip().split('=',1)
                 os.environ[k]=v.strip('"')
 
+MAX_CONCURRENT_TASKS = int(os.getenv("MAX_CONCURRENT_TASKS", "2"))
+RATE_LIMIT_PER_MIN = int(os.getenv("RATE_LIMIT_PER_MIN", "5"))
+DEFAULT_TIMEOUT = int(os.getenv("TASK_TIMEOUT", "900"))
+
+request_times = deque()
+pending_tasks: Dict[str, Dict] = {}
+running_tasks: Dict[str, asyncio.Task] = {}
+completed_tasks: Dict[str, Dict] = {}
+task_queue: asyncio.Queue[str] = asyncio.Queue()
+semaphore = asyncio.Semaphore(MAX_CONCURRENT_TASKS)
+
 app = FastAPI(title="Coding Swarm API", version="2.0.0")
 
 class RunRequest(BaseModel):
@@ -23,6 +35,63 @@ class RunRequest(BaseModel):
     project: str = "."
     model: Optional[str] = None
     dry_run: bool = False
+    timeout: Optional[int] = None
+
+
+async def worker():
+    while True:
+        task_id = await task_queue.get()
+        info = pending_tasks.pop(task_id, None)
+        if not info:
+            continue  # cancelled before start
+        await semaphore.acquire()
+        running_tasks[task_id] = asyncio.create_task(execute(task_id, info))
+
+
+async def execute(task_id: str, info: Dict):
+    cmd = [
+        "python3",
+        str(Path(__file__).with_name("swarm_orchestrator.py")),
+        "run",
+        "--goal",
+        info["goal"],
+        "--project",
+        info["project"],
+    ]
+    if info.get("model"):
+        cmd.extend(["--model", info["model"]])
+    if info.get("dry_run"):
+        cmd.append("--dry-run")
+
+    proc = await asyncio.create_subprocess_exec(
+        *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+    )
+    timeout = info.get("timeout") or DEFAULT_TIMEOUT
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        completed_tasks[task_id] = {
+            "status": "completed",
+            "returncode": proc.returncode,
+            "stdout": stdout.decode(),
+            "stderr": stderr.decode(),
+        }
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        completed_tasks[task_id] = {"status": "timeout"}
+    except asyncio.CancelledError:
+        proc.kill()
+        await proc.wait()
+        completed_tasks[task_id] = {"status": "cancelled"}
+        raise
+    finally:
+        running_tasks.pop(task_id, None)
+        semaphore.release()
+
+
+@app.on_event("startup")
+async def on_startup():
+    asyncio.create_task(worker())
 
 @app.get("/health")
 async def health():
@@ -42,7 +111,53 @@ async def run(req: RunRequest):
     proj = Path(req.project).resolve()
     if not proj.exists():
         raise HTTPException(400, "Project directory does not exist")
-    return {"received": req.dict(), "ts": datetime.utcnow().isoformat()}
+    now = time.time()
+    while request_times and now - request_times[0] > 60:
+        request_times.popleft()
+    if len(request_times) >= RATE_LIMIT_PER_MIN:
+        raise HTTPException(429, "Too many requests")
+    request_times.append(now)
+    task_id = uuid.uuid4().hex
+    pending_tasks[task_id] = {
+        "goal": req.goal,
+        "project": str(proj),
+        "model": req.model,
+        "dry_run": req.dry_run,
+        "timeout": req.timeout,
+    }
+    await task_queue.put(task_id)
+    return {"task_id": task_id, "status": "queued"}
+
+
+@app.get("/queue/status")
+async def queue_status():
+    return {
+        "running": {
+            "ids": list(running_tasks.keys()),
+            "count": len(running_tasks),
+        },
+        "pending": {
+            "ids": list(pending_tasks.keys()),
+            "count": len(pending_tasks),
+        },
+        "completed": {
+            "ids": list(completed_tasks.keys()),
+            "count": len(completed_tasks),
+        },
+    }
+
+
+@app.delete("/queue/{task_id}")
+async def cancel_task(task_id: str):
+    if task_id in pending_tasks:
+        pending_tasks.pop(task_id, None)
+        return {"status": "cancelled"}
+    if task_id in running_tasks:
+        running_tasks[task_id].cancel()
+        return {"status": "cancelling"}
+    if task_id in completed_tasks:
+        return {"status": "completed"}
+    raise HTTPException(404, "Task not found")
 
 if __name__ == "__main__":
     host=os.getenv("API_HOST","127.0.0.1")


### PR DESCRIPTION
## Summary
- run orchestrator jobs asynchronously using an internal queue with concurrency limits
- expose `/queue/status` to report pending, running, and completed tasks
- add request rate limiting plus cancellation and timeout handling for long jobs

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile bin/swarm_api.py bin/swarm_orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_68aca45a67148324bbbed0af439bb90c