### PR TITLE
Kilo-style multi-agent upgrade (local-model-first)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,22 @@ Agents (llama.cpp) expected on:
 
 Place a GGUF at: /opt/models/Qwen2.5-Coder-7B-Instruct-Q4_K_M.gguf
 Official llama.cpp server image: ghcr.io/ggerganov/llama.cpp:server  (HTTP API doc in repo). :contentReference[oaicite:6]{index=6}
+
+## LLM Provider configuration
+
+Coding‑Swarm now uses a pluggable provider layer.  By default it expects an
+OpenAI‑compatible server running locally (for example `llama.cpp`) and will
+connect to `http://127.0.0.1:8080/v1` using the model name from
+`OPENAI_MODEL`.
+
+Environment variables:
+
+- `OPENAI_BASE_URL` – API base URL (default `http://127.0.0.1:8080/v1`)
+- `OPENAI_API_KEY` – API token (default `sk-local`)
+- `OPENAI_MODEL` – model identifier (default `llama-3.1`)
+- `CSWARM_PROVIDER` – provider name (currently only `openai-compatible`)
+
+The CLI entry point `bin/sanaa_orchestrator.py` also accepts `--provider` to
+override the provider on a per‑run basis.
 # coding-swarm
 # coding-swarm

--- a/api/providers.py
+++ b/api/providers.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import os
+import json
+from typing import List, Dict, Any, Optional
+
+import httpx
+
+
+class BaseProvider:
+    """Abstract LLM provider."""
+
+    def chat(self, messages: List[Dict[str, Any]], **kwargs: Any) -> str:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class OpenAICompatibleProvider(BaseProvider):
+    """Provider for OpenAI-compatible chat completions APIs.
+
+    Defaults to using a locally hosted server such as ``llama.cpp``
+    running on ``http://127.0.0.1:8080/v1``.  The endpoint and model can be
+    overridden via ``OPENAI_BASE_URL``, ``OPENAI_API_KEY`` and
+    ``OPENAI_MODEL`` environment variables.
+    """
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        timeout: float = 120.0,
+    ) -> None:
+        self.base_url = base_url or os.getenv("OPENAI_BASE_URL", "http://127.0.0.1:8080/v1")
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY", "sk-local")
+        self.model = model or os.getenv("OPENAI_MODEL", "llama-3.1")
+        self.timeout = timeout
+
+    def _endpoint(self) -> str:
+        base = self.base_url.rstrip("/")
+        path = "/chat/completions" if base.endswith("/v1") else "/v1/chat/completions"
+        return base + path
+
+    def chat(
+        self,
+        messages: List[Dict[str, Any]],
+        temperature: float = 0.2,
+        max_tokens: int = 2048,
+    ) -> str:
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        }
+        with httpx.Client(timeout=self.timeout) as client:
+            response = client.post(self._endpoint(), json=payload, headers=headers)
+            response.raise_for_status()
+            data = response.json()
+        try:
+            return data["choices"][0]["message"]["content"]
+        except Exception:
+            return json.dumps(data, indent=2)
+
+
+PROVIDER_REGISTRY = {
+    "openai-compatible": OpenAICompatibleProvider,
+}
+
+
+def get_provider(name: Optional[str] = None) -> BaseProvider:
+    """Return provider instance by ``name`` (env ``CSWARM_PROVIDER``)."""
+    name = name or os.getenv("CSWARM_PROVIDER", "openai-compatible")
+    cls = PROVIDER_REGISTRY.get(name, OpenAICompatibleProvider)
+    return cls()

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pathlib, sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import agents.tester
+from orchestrator.orchestrator import orchestrate
+
+
+def test_orchestrator_flow(monkeypatch, tmp_path):
+    def fake_run(cmd, capture_output, text):
+        class R:
+            returncode = 0
+            stdout = "ok"
+            stderr = ""
+        return R()
+
+    monkeypatch.setattr(agents.tester.subprocess, "run", fake_run)
+    ctx = orchestrate("demo goal", project=str(tmp_path))
+    assert ctx["success"] is True
+    assert "plan" in ctx

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+import pathlib, sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import api.providers as providers
+from api.providers import OpenAICompatibleProvider, get_provider
+
+
+def test_openai_provider_uses_base_url(monkeypatch):
+    calls = {}
+
+    class DummyResp:
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            pass
+
+        def json(self) -> dict:
+            return {"choices": [{"message": {"content": "ok"}}]}
+
+    class DummyClient:
+        def __init__(self, timeout):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def post(self, url, json, headers):  # type: ignore[override]
+            calls["url"] = url
+            calls["payload"] = json
+            calls["headers"] = headers
+            return DummyResp()
+
+    monkeypatch.setattr(providers, "httpx", SimpleNamespace(Client=DummyClient))
+
+    provider = OpenAICompatibleProvider()
+    result = provider.chat([{"role": "user", "content": "hi"}])
+    assert result == "ok"
+    assert calls["url"].startswith("http://127.0.0.1:8080")
+    assert calls["payload"]["model"] == provider.model
+
+
+def test_get_provider_default():
+    prov = get_provider()
+    assert isinstance(prov, OpenAICompatibleProvider)


### PR DESCRIPTION
## Summary
- add pluggable provider abstraction for OpenAI-compatible endpoints
- refactor CLI orchestrator and test generator to use provider layer
- add unit tests for provider registry and orchestrator flow

## Testing
- `pytest tests/test_provider.py tests/test_orchestrator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ace1d4b0488324bd486141e7f4249b